### PR TITLE
Use viewport parent's local coordinate system rather than global

### DIFF
--- a/src/plugins/Drag.ts
+++ b/src/plugins/Drag.ts
@@ -413,7 +413,6 @@ export class Drag extends Plugin
             if (pointer.last)
             {
                 this.last = { x: pointer.last.x, y: pointer.last.y };
-                (this.parent.parent || this.parent).toLocal(this.last, undefined, this.last);
                 this.current = pointer.id;
             }
             this.moved = false;

--- a/src/plugins/Drag.ts
+++ b/src/plugins/Drag.ts
@@ -324,6 +324,7 @@ export class Drag extends Plugin
         if (this.checkButtons(event) && this.checkKeyPress(event))
         {
             this.last = { x: event.global.x, y: event.global.y };
+            (this.parent.parent || this.parent).toLocal(this.last, undefined, this.last);
             this.current = event.pointerId;
 
             return true;
@@ -360,6 +361,8 @@ export class Drag extends Plugin
                     || (this.yDirection && this.parent.input.checkThreshold(distY))))
                 {
                     const newPoint = { x, y };
+
+                    (this.parent.parent || this.parent).toLocal(newPoint, undefined, newPoint);
 
                     if (this.xDirection)
                     {
@@ -410,6 +413,7 @@ export class Drag extends Plugin
             if (pointer.last)
             {
                 this.last = { x: pointer.last.x, y: pointer.last.y };
+                (this.parent.parent || this.parent).toLocal(this.last, undefined, this.last);
                 this.current = pointer.id;
             }
             this.moved = false;
@@ -421,6 +425,8 @@ export class Drag extends Plugin
             if (this.moved)
             {
                 const screen = new Point(this.last.x, this.last.y);
+
+                (this.parent.parent || this.parent).toGlobal(screen, screen, true);
 
                 this.parent.emit('drag-end', {
                     event, screen,
@@ -511,8 +517,7 @@ export class Drag extends Plugin
                         this.parent.x = (this.parent.screenWidth - this.parent.screenWorldWidth) / 2;
                 }
             }
-            else
-            if (this.parent.left < 0)
+            else if (this.parent.left < 0)
             {
                 this.parent.x = 0;
                 decelerate.x = 0;

--- a/src/plugins/Drag.ts
+++ b/src/plugins/Drag.ts
@@ -353,17 +353,17 @@ export class Drag extends Plugin
 
             if (count === 1 || (count > 1 && !this.parent.plugins.get('pinch', true)))
             {
-                const distX = x - this.last.x;
-                const distY = y - this.last.y;
+                const newPoint = { x, y };
+
+                (this.parent.parent || this.parent).toLocal(newPoint, undefined, newPoint);
+
+                const distX = newPoint.x - this.last.x;
+                const distY = newPoint.y - this.last.y;
 
                 if (this.moved
                     || ((this.xDirection && this.parent.input.checkThreshold(distX))
                     || (this.yDirection && this.parent.input.checkThreshold(distY))))
                 {
-                    const newPoint = { x, y };
-
-                    (this.parent.parent || this.parent).toLocal(newPoint, undefined, newPoint);
-
                     if (this.xDirection)
                     {
                         this.parent.x += (newPoint.x - this.last.x) * this.options.factor;

--- a/src/plugins/Pinch.ts
+++ b/src/plugins/Pinch.ts
@@ -41,6 +41,8 @@ const DEFAULT_PINCH_OPTIONS: Required<IPinchOptions> = {
     axis: 'all',
 };
 
+const SCRATCH_POINT = new Point();
+
 /**
  * Plugin for enabling two-finger pinching (or dragging).
  *
@@ -98,8 +100,7 @@ export class Pinch extends Plugin
             return false;
         }
 
-        const x = e.global.x;
-        const y = e.global.y;
+        const { x, y } = (this.parent.parent || this.parent).toLocal(e.global, undefined, SCRATCH_POINT);
 
         const pointers = this.parent.input.touches;
 
@@ -130,7 +131,7 @@ export class Pinch extends Plugin
 
                 if (!this.options.center)
                 {
-                    oldPoint = this.parent.toLocal(point);
+                    oldPoint = this.parent.toLocal(point, this.parent.parent || this.parent);
                 }
                 let dist = Math.sqrt(Math.pow(
                     (second.last as IPointData).x - (first.last as IPointData).x, 2)
@@ -164,7 +165,7 @@ export class Pinch extends Plugin
                 }
                 else
                 {
-                    const newPoint = this.parent.toGlobal(oldPoint as IPointData);
+                    const newPoint = (this.parent.parent || this.parent).toLocal(oldPoint as IPointData, this.parent);
 
                     this.parent.x += (point.x - newPoint.x) * this.options.factor;
                     this.parent.y += (point.y - newPoint.y) * this.options.factor;

--- a/src/plugins/Wheel.ts
+++ b/src/plugins/Wheel.ts
@@ -202,10 +202,11 @@ export class Wheel extends Plugin
             }
             else
             {
-                const newPoint = this.parent.toGlobal(oldPoint as IPointData);
+                this.parent.parent.toLocal(oldPoint as IPointData, this.parent, oldPoint);
+                const comparePoint = this.parent.parent.toLocal(point as IPointData);
 
-                this.parent.x += (point as IPointData).x - newPoint.x;
-                this.parent.y += (point as IPointData).y - newPoint.y;
+                this.parent.x += comparePoint.x - (oldPoint as IPointData).x;
+                this.parent.y += comparePoint.y - (oldPoint as IPointData).y;
             }
 
             this.parent.emit('moved', { viewport: this.parent, type: 'wheel' });
@@ -256,14 +257,15 @@ export class Wheel extends Plugin
         }
         else
         {
-            const newPoint = this.parent.toGlobal(oldPoint as IPointData);
+            this.parent.parent.toLocal(oldPoint as IPointData, this.parent, oldPoint);
+            const comparePoint = this.parent.parent.toLocal(point as IPointData);
 
-            this.parent.x += point.x - newPoint.x;
-            this.parent.y += point.y - newPoint.y;
+            this.parent.x += comparePoint.x - (oldPoint as IPointData).x;
+            this.parent.y += comparePoint.y - (oldPoint as IPointData).y;
         }
+
         this.parent.emit('moved', { viewport: this.parent, type: 'wheel' });
-        this.parent.emit('wheel-start',
-            { event: e, viewport: this.parent });
+        this.parent.emit('wheel-start', { event: e, viewport: this.parent });
     }
 
     public wheel(e: WheelEvent): boolean
@@ -332,10 +334,11 @@ export class Wheel extends Plugin
                 }
                 else
                 {
-                    const newPoint = this.parent.toGlobal(oldPoint as IPointData);
+                    this.parent.parent.toLocal(oldPoint as IPointData, this.parent, oldPoint);
+                    const comparePoint = this.parent.parent.toLocal(point as IPointData);
 
-                    this.parent.x += point.x - newPoint.x;
-                    this.parent.y += point.y - newPoint.y;
+                    this.parent.x += comparePoint.x - (oldPoint as IPointData).x;
+                    this.parent.y += comparePoint.y - (oldPoint as IPointData).y;
                 }
             }
 


### PR DESCRIPTION
Addresses https://github.com/davidfig/pixi-viewport/issues/49

Currently this library assumes that the Viewport exists in global coordinate space, i.e, on the root stage or in an unscaled container on the stage, and it breaks when in a transformed container. This attempts to address this by getting the coordinates in the local space of the viewport's parent instead of global coordinates.